### PR TITLE
Reworked and tested cve retrieval tool

### DIFF
--- a/Scraping/apple_cve.py
+++ b/Scraping/apple_cve.py
@@ -1,32 +1,72 @@
 # Apple's current CVE list from
 # circl.lu
-# pulling 400 of the CVE's
+# pull all the CVE's
 
-import urllib.request
+import datetime
 import json
+import logging
+
 import pandas as pd
+import urllib.request
 
-# getting the url
-f = urllib.request.urlopen('https://cve.circl.lu/api/search/apple/mac_os')
 
-# decoding the text
-json_string = f.read().decode('utf-8')
+def get_json():
+    """
+    Pull JSON of OSX vulnerabilities, parse it, and return.
 
-# parsing the information
-parsed_json = json.loads(json_string)
+    :return: Dict; all CVE entries returned from API.
+    """
+    logging.info('Starting JSON retrieval...')
+    start = datetime.datetime.now()
+    # getting the url
+    f = urllib.request.urlopen('https://cve.circl.lu/api/search/apple/mac_os')
 
-records = []
-num = 0
-while (num < 400):
-    cve = parsed_json[num].get('id', None)
-    cwe = parsed_json[num].get('cwe', None)
-    summary = parsed_json[num].get('summary', None)
-    published = parsed_json[num].get('Published', None)
-    last_modified = parsed_json[num].get('last-modified', None)
-    records.append((cve, cwe, summary, published, last_modified))
-    num = num + 1
+    # decoding the text
+    logging.info('Starting JSON decode. This may take a few minutes.')
+    json_string = f.read().decode('utf-8')
+    f.close()
 
-#export to csv
-df = pd.DataFrame(records, columns=('cve', 'cwe', 'summary', 'published', 'last_modified'))
-df.to_csv('cve_apple.csv', index=False, encoding='utf-8')
-f.close()
+    # parsing the information
+    parsed_json = json.loads(json_string)
+
+    end = datetime.datetime.now()
+    logging.info(
+        'JSON decode finished. Processing time: {} seconds.'.format((end-start).seconds)
+    )
+
+    return parsed_json
+
+
+def format_for_spreadsheet(api_results):
+    logging.info('Parsing records...')
+
+    records = list()
+
+    for record in api_results:
+        cve = record.get('id', None)
+        cwe = record.get('cwe', 'Unknown')
+        summary = record.get('summary', 'Unknown')
+        published = record.get('Published', 'Unknown')
+        last_modified = record.get('last-modified', 'Unknown')
+        records.append((cve, cwe, summary, published, last_modified))
+
+    return records
+
+
+def create_csv(records):
+    logging.info('Starting CSV export...')
+    df = pd.DataFrame(records, columns=('cve', 'cwe', 'summary', 'published', 'last_modified'))
+    df.to_csv('cve_apple.csv', index=False, encoding='utf-8')
+    logging.info('CSV export complete.')
+
+
+def main():
+    cve_data = get_json()
+    results = format_for_spreadsheet(cve_data)
+    create_csv(results)
+
+if __name__ == '__main__':
+    FORMAT = '[%(levelname)s] - [%(funcName)s] - %(message)s'
+    logging.basicConfig(level=logging.INFO, format=FORMAT)
+
+    main()


### PR DESCRIPTION
## Overview

So actually, most of this is formatting and layout changes. The only real code changes I ended up needing to make were to start the loop.

Where we were doing is...

```python
while (num < 400):
    cve = parsed_json[num].get('id', None)
    ...
```

...and we can actually make this a lot simpler by changing how we interact with the dictionary.

I know you already know this next part, but I'm going to lay it out real quick just so we have a visual. If the dictionary is laid out as an object that is a collection of objects, we have:

```python
{
  {"cve": "123", "cwe": "456", ...},
  {"cve": "789", "cwe": "981", ...},
  {"cve": "158", "cwe": "651", ...}
  ...
}
```
And sure, we can access it by requesting the object that we want from the dict, like `json_dict[object_num]`. But if we change the loop so that we're only working with each sub-object at a time, then we can massively simplify the amount of work needed.

```python
for object in json_dict:
    print(object.get("cve", None))
    print(object.get("cwe", "Unknown"))
    ...
```
The nice thing about doing it this way is that Python will automatically handle pulling each sub-object out for us and will end the loop automatically when we're out of objects. That solves the original issue, so let's take a look at some of the other things I added.

## Logging

One thing I noticed immediately is that if the data isn't cached, the process of grabbing the JSON can take upwards of 10 minutes! At first I was confused that nothing was happening, but then added in some logging just to prove to myself that things were actually happening as they were supposed to. Using logging in this particular context is super easy -- we have the import statement and then the `logging.basicConfig()` call. We don't even need the `FORMAT` bit -- that's just something I have handy because I think it's useful :smile:

Here's what it looks like on two consecutive runs:
![screen shot 2017-10-26 at 11 28 12 pm](https://user-images.githubusercontent.com/5179553/32086763-687e366c-baa5-11e7-8931-e0019d2a1fb5.png)

So with logging out of the way and now that we know it's actually doing what we want it to do, let's take a look at the formatting.

## Modularization & Abstraction

Some of the stuff that we're doing here can definitely be re-used in the Microsoft CVE one, so this is a great first step towards making it modular so that one can import from the other and you can save yourself a lot of code. Mostly, I just tried to break everything out into the three levels of abstraction: 
1) be able to get a general overview
2) do the work
3) have some room for extra abstraction if one level isn't enough

In this case we actually do well with only two layers of abstraction (`main()` and the functions that `main()` calls to do the work), so with some small tweaks it will import nicely. Beyond that, it's just passing data back and forth between functions with the end goal of making it importable for future use. (Oh, and I sorted the imports by PEP-8, but that's barely worth mentioning.)

Whew, that's an awful lot of typing. Let me know what you think -- will be glad to discuss tomorrow 👍 
